### PR TITLE
Simplify Windows ARM CI setup.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,18 +82,11 @@ jobs:
           - os: windows-2025
             python-version: '3.13'
           - os: windows-11-arm
-            python-version: '3.13'
+            # N.B.: An aarch64 interpreter must still be asked for explicitly on Windows ARM64.
+            python-version: 'cpython-3.13-windows-aarch64'
     steps:
       - name: Checkout pexcz
         uses: actions/checkout@v4
-      - name: Install Python
-        if: matrix.os == 'windows-11-arm'
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Configure Python
-        if: matrix.os == 'windows-11-arm'
-        run: echo "UV_NO_MANAGED_PYTHON=1" >> "${GITHUB_ENV}"
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ module = ["pkg_resources.*"]
 follow_imports = "skip"
 
 [tool.uv]
-required-version = ">=0.6"
+required-version = ">=0.7.18"
 # TODO(John Sirois): The one case this doesn't cover is removal of the zig artifacts from
 #  src/python/pexcz/__pex__/.lib. Currently, uv is blind to this.
 cache-keys = [


### PR DESCRIPTION
As of uv 0.7.18, PBS Windows arm can be fetched.